### PR TITLE
Add $ReadOnlyArray to accepted input types

### DIFF
--- a/src/maybe.js
+++ b/src/maybe.js
@@ -4,7 +4,7 @@
 
 export type Maybe<A> = Just<A> | Nothing
 
-type AnyVal = number | boolean | string | Object | Array<*>
+type AnyVal = number | boolean | string | Object | Array<*> | $ReadOnlyArray<*>
 
 class Just<A> {
 

--- a/src/maybe.js.flow
+++ b/src/maybe.js.flow
@@ -2,7 +2,7 @@
 
 export type Maybe<A> = Just<A> | Nothing
 
-type AnyVal = number | boolean | string | Object | Array<*>
+type AnyVal = number | boolean | string | Object | Array<*> | $ReadOnlyArray<*>
 
 declare class Just<A> {
   filter(p: (_: A) => boolean): Maybe<A>;


### PR DESCRIPTION
I use `$ReadOnlyArray`s extensively for immutability safety, this change allows us to use them with `maybe`!